### PR TITLE
Added the catkin workspace CMakeLists.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ devel/
 bundle/
 install/
 .catkin_workspace
+smile_mobile_robot_ws/src/CMakeLists.txt
+smile_mobile_sim_ws/src/CMakeLists.txt
+smile_mobile_robot_ws/log/
+smile_mobile_sim_ws/log/

--- a/smile_mobile_robot_ws/src/CMakeLists.txt
+++ b/smile_mobile_robot_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/opt/ros/melodic/share/catkin/cmake/toplevel.cmake

--- a/smile_mobile_sim_ws/src/CMakeLists.txt
+++ b/smile_mobile_sim_ws/src/CMakeLists.txt
@@ -1,1 +1,0 @@
-/opt/ros/melodic/share/catkin/cmake/toplevel.cmake


### PR DESCRIPTION
The catkin workspace CMakeLists.txt should be ignored because it is not needed and causes issues with colcon bundle. Note, this is different from the CMakeLists.txt that ROS packages require.